### PR TITLE
Fix slackclient package version to 1.3.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 chaostoolkit-lib>=0.15.0
 logzero
-slackclient
+slackclient>=1.3.1,<2


### PR DESCRIPTION
In the new slackclient package versions, you can't import the module with the name `slackclient` but should use `slack` instead:

```
>>> import chaosslack.notification
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.6/site-packages/chaosslack/notification.py", line 7, in <module>
    from slackclient import SlackClient
ModuleNotFoundError: No module named 'slackclient'
```

Since I don't know what are the other changes with versions >= 2.0.0 yet, here's a quick fix.